### PR TITLE
#14 Enhancements to current implementation for syllabus

### DIFF
--- a/provider-syllabus/src/java/org/sakaiproject/archiver/provider/SyllabusArchiver.java
+++ b/provider-syllabus/src/java/org/sakaiproject/archiver/provider/SyllabusArchiver.java
@@ -27,14 +27,14 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class SyllabusArchiver implements Archiveable {
 
-	private static final String HOME_TOOL = "sakai.syllabus";
+	private static final String SYLLABUS_TOOL = "sakai.syllabus";
 
 	public void init() {
-		ArchiverRegistry.getInstance().register(HOME_TOOL, this);
+		ArchiverRegistry.getInstance().register(SYLLABUS_TOOL, this);
 	}
 
 	public void destroy() {
-		ArchiverRegistry.getInstance().unregister(HOME_TOOL);
+		ArchiverRegistry.getInstance().unregister(SYLLABUS_TOOL);
 	}
 
 	@Setter

--- a/provider-syllabus/src/java/org/sakaiproject/archiver/provider/SyllabusArchiver.java
+++ b/provider-syllabus/src/java/org/sakaiproject/archiver/provider/SyllabusArchiver.java
@@ -57,12 +57,8 @@ public class SyllabusArchiver implements Archiveable {
 		Set<SyllabusData> syllabusSet = this.syllabusManager.getSyllabiForSyllabusItem(siteSyllabus);
 
 		// Go through and archive each syllabus item
-		ArchiveItem archiveItem = new ArchiveItem();
 		for (SyllabusData syllabus : syllabusSet) {
-			archiveItem.setTitle(syllabus.getTitle());
-			archiveItem.setStartDate(syllabus.getStartDate());
-			archiveItem.setEndDate(syllabus.getEndDate());
-			archiveItem.setBody(syllabus.getAsset());
+			ArchiveItem archiveItem = createArchiveItem(syllabus);
 			String jsonArchiveItem = Jsonifier.toJson(archiveItem);
 			log.debug("Archive item metadata: " + jsonArchiveItem);
 			this.archiverService.archiveContent(archiveId, siteId, toolId, jsonArchiveItem.getBytes(), archiveItem.getTitle() + ".json");
@@ -81,6 +77,23 @@ public class SyllabusArchiver implements Archiveable {
 				}
 			}
 		}
+	}
+	
+	
+	/**
+	 * Build the ArchiveItem for a syllabus item
+	 * @param syllabus
+	 * @return the archive item to be saved
+	 */
+	private ArchiveItem createArchiveItem(SyllabusData syllabus) {
+		
+		ArchiveItem archiveItem = new ArchiveItem();
+		archiveItem.setTitle(syllabus.getTitle());
+		archiveItem.setStartDate(syllabus.getStartDate());
+		archiveItem.setEndDate(syllabus.getEndDate());
+		archiveItem.setBody(syllabus.getAsset());
+		
+		return archiveItem;
 	}
 	
 	/**


### PR DESCRIPTION
Updates to #14 
Merged content and metadata, now that Jsonifier can handle html (as of #21)
Removed some some debugging that is not useful.
Updated call to archiveContent to use the passed in toolId rather than hardcoding it.